### PR TITLE
Added creatisbot to the whitelist

### DIFF
--- a/whitelist.json
+++ b/whitelist.json
@@ -16,5 +16,6 @@
     "streamjar",
     "overrustlelogs",
     "amazeful",
-    "amazefulbot"
+    "amazefulbot",
+    "creatisbot"
 ]


### PR DESCRIPTION
Hey!:

Creatisbot is the bot present on chat when you're using [Isaiah Creati's Channel rewards TTS](https://www.isaiahcreati.com/channel-points). To avoid problems, this bot should be added to the whitelist.

