### PR TITLE
Add wzbot to whitelist

### DIFF
--- a/whitelist.json
+++ b/whitelist.json
@@ -21,5 +21,6 @@
     "soundalerts",
     "fossabot",
     "mikuia",
-    "rainmaker"
+    "rainmaker",
+    "wzbot"
 ]


### PR DESCRIPTION
wzbot is a version of wizebot, as mentioned here: https://www.twitch.tv/wzbot

Fixes https://github.com/MrEliasen/twitch-bot-list/issues/26